### PR TITLE
替换文档中SDK地址为最新

### DIFF
--- a/docs/integration/Installation.md
+++ b/docs/integration/Installation.md
@@ -21,7 +21,7 @@ yarn add @ohbug/browser
 使用 Script 方式接入时需要注意将 Ohbug 脚本放在其他脚本之前，推荐放在 `head` 标签头部。
 
 ```html
-<script src="https://cdn.jsdelivr.net/npm/@ohbug/browser@1.0.6-alpha.0/dist/ohbug-browser.global.prod.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/@ohbug/browser@1.0.16/dist/ohbug-browser.umd.min.js"></script>
 <script>
   var client = Ohbug.Client.init({
     apiKey: 'YOUR_API_KEY',


### PR DESCRIPTION
替换最新的SDK地址。

旧版本SDK的/report接口没有sdk字段，导致pg数据库插入event表的sdk字段为空（sdk字段是必填列）

![image](https://user-images.githubusercontent.com/36876080/126022471-0d012a84-66ba-4cd0-b503-a00b68219f82.png)

![image](https://user-images.githubusercontent.com/36876080/126022476-0c56032d-8d8e-4d7c-b4fd-e108816a10a0.png)

